### PR TITLE
corrected 2 rspec syntax errors

### DIFF
--- a/spec/controllers/period_controller_spec.rb
+++ b/spec/controllers/period_controller_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
-RSpec.describe PeriodController, type: :controller do
+RSpec.describe PeriodsController, type: :controller do
 
 end

--- a/spec/views/workflow_steps/edit.html.erb_spec.rb
+++ b/spec/views/workflow_steps/edit.html.erb_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-require 'pp'
 
 RSpec.describe "workflow_steps/edit", type: :view do
   before(:each) do

--- a/spec/views/workflow_steps/edit.html.erb_spec.rb
+++ b/spec/views/workflow_steps/edit.html.erb_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require 'pp'
 
 RSpec.describe "workflow_steps/edit", type: :view do
   before(:each) do
@@ -10,8 +11,8 @@ RSpec.describe "workflow_steps/edit", type: :view do
   it "renders the edit workflow_step form" do
     render
 
-    assert_select "form[action=?][method=?]", workflow_step_path(params[:slug]@workflow_step), "post" do
-
+    assert_select "form[action=?][method=?]", workflow_step_path(params[:slug], @workflow_step), "post" do
+    
       assert_select "input[name=?]", "workflow_step[slug]"
     end
   end


### PR DESCRIPTION
rspec now runs without syntax error however none of the tests apeare to be successful

`workflow_step_path(params[:slug], @workflow_step)`  probably should be 
`workflow_step_path(params[:slug],workflow_step, org_path:params[:org_path])` I don't know for sure 